### PR TITLE
Add simulate only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can customize all of the deployment parameters of the LSP simply by changing
 --basePercentage: The percentage of collateral per pair used as the floor. This parameter is used with the 'SuccessToken' fpl where the remaining percentage functions like an embedded call option.
 --lowerBound: Lower bound of a price range for certain financial product libraries. Cannot be included if --strikePrice is specified.
 --upperBound: Upper bound of a price range for certain financial product libraries.
---simulate: Boolean telling if set the script should only simulate the transactions without sending them to the network.
+--simulate: Boolean telling if the script should only simulate the transactions without sending them to the network.
 ```
 
 Your financial product library address defines the payout function for your LSP. We have several [financial product libraries](https://github.com/UMAprotocol/protocol/tree/master/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries) available for transforming the price, identifier, or collateral requirement of an LSP before or after expiry.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ You can customize all of the deployment parameters of the LSP simply by changing
 --basePercentage: The percentage of collateral per pair used as the floor. This parameter is used with the 'SuccessToken' fpl where the remaining percentage functions like an embedded call option.
 --lowerBound: Lower bound of a price range for certain financial product libraries. Cannot be included if --strikePrice is specified.
 --upperBound: Upper bound of a price range for certain financial product libraries.
+--simulate: Boolean telling if set the script should only simulate the transactions without sending them to the network.
 ```
 
 Your financial product library address defines the payout function for your LSP. We have several [financial product libraries](https://github.com/UMAprotocol/protocol/tree/master/packages/core/contracts/financial-templates/common/financial-product-libraries/long-short-pair-libraries) available for transforming the price, identifier, or collateral requirement of an LSP before or after expiry.

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const { parseFixed } = require("@ethersproject/bignumber");
 // --basePercentage: The percentage of collateral per pair used as the floor. This parameter is used with the 'SuccessToken' fpl where the remaining percentage functions like an embedded call option.
 // --lowerBound: Lower bound of a price range for certain financial product libraries. Cannot be included if --strikePrice is specified.
 // --upperBound: Upper bound of a price range for certain financial product libraries.
+// --simulate: Boolean telling if the script should only simulate the transactions without sending them to the network.
 // 
 //
 // Example deployment script:

--- a/index.js
+++ b/index.js
@@ -65,7 +65,6 @@ const argv = require("minimist")(process.argv.slice(), {
   boolean: [ "simulate" ]
 });
 
-if (!argv.simulate) { console.log('YES') };
 if (!argv.gasprice) throw "--gasprice required (in GWEI)";
 // if (typeof argv.gasprice !== "number") throw "--gasprice must be a number";
 if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between 1 and 1000 (GWEI)";

--- a/index.js
+++ b/index.js
@@ -61,9 +61,11 @@ const argv = require("minimist")(process.argv.slice(), {
     "optimisticOracleLivenessTime",
     "optimisticOracleProposerBond",
     "gasprice"
-  ]
+  ],
+  boolean: [ "simulate" ]
 });
 
+if (!argv.simulate) { console.log('YES') };
 if (!argv.gasprice) throw "--gasprice required (in GWEI)";
 // if (typeof argv.gasprice !== "number") throw "--gasprice must be a number";
 if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between 1 and 1000 (GWEI)";
@@ -176,8 +178,10 @@ const livenessTime = argv.optimisticOracleLivenessTime ? argv.optimisticOracleLi
   console.log("Simulation successful. Expected Address:", address);
 
   // Since the simulated transaction succeeded, send the real one to the network.
-  const { transactionHash } = await lspCreator.methods.createLongShortPair(lspParams).send(transactionOptions);
-  console.log("Deployed in transaction:", transactionHash);
+  if (!argv.simulate) {
+    const { transactionHash } = await lspCreator.methods.createLongShortPair(lspParams).send(transactionOptions);
+    console.log("Deployed in transaction:", transactionHash);
+  }
 
   // Set the FPL parameters.
   if (fpl) {
@@ -195,8 +199,10 @@ const livenessTime = argv.optimisticOracleLivenessTime ? argv.optimisticOracleLi
         address: fplParams[0],
         lowerBound: fplParams[1]
       });
-      const { transactionHash } = await deployedFPL.methods.setLongShortPairParameters(...fplParams).send(transactionOptions);
-      console.log("Financial product library parameters set in transaction:", transactionHash);
+      if (!argv.simulate) {
+        const { transactionHash } = await deployedFPL.methods.setLongShortPairParameters(...fplParams).send(transactionOptions);
+        console.log("Financial product library parameters set in transaction:", transactionHash);
+      }
     }
     if (argv.fpl == 'RangeBond' || argv.fpl == 'Linear') {
       const upperBound = argv.upperBound;
@@ -206,8 +212,10 @@ const livenessTime = argv.optimisticOracleLivenessTime ? argv.optimisticOracleLi
         upperBound: fplParams[1],
         lowerBound: fplParams[2]
       });
-      const { transactionHash } = await deployedFPL.methods.setLongShortPairParameters(...fplParams).send(transactionOptions);
-      console.log("Financial product library parameters set in transaction:", transactionHash);
+      if (!argv.simulate) {
+        const { transactionHash } = await deployedFPL.methods.setLongShortPairParameters(...fplParams).send(transactionOptions);
+        console.log("Financial product library parameters set in transaction:", transactionHash);
+      }
     }
     if (argv.fpl == 'SuccessToken') {
       const basePercentage = argv.basePercentage;
@@ -217,8 +225,10 @@ const livenessTime = argv.optimisticOracleLivenessTime ? argv.optimisticOracleLi
         lowerBound: fplParams[1],
         basePercentage: fplParams[2]
       });
-      const { transactionHash } = await deployedFPL.methods.setLongShortPairParameters(...fplParams).send(transactionOptions);
-      console.log("Financial product library parameters set in transaction:", transactionHash);
+      if (!argv.simulate) {
+        const { transactionHash } = await deployedFPL.methods.setLongShortPairParameters(...fplParams).send(transactionOptions);
+        console.log("Financial product library parameters set in transaction:", transactionHash);
+      }
     }
   }
   process.exit(0);


### PR DESCRIPTION
This allows passing `--simulate` parameter that shows only simulated transactions without sending them to the network.