### PR TITLE
feat: update packages and lsp address

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,13 +177,19 @@ const earlyExpiration = argv.enableEarlyExpiration ? argv.enableEarlyExpiration 
 
   // Simulate transaction to test before sending to the network.
   console.log("Simulating Deployment...");
-  const address = await lspCreator.methods.createLongShortPair(lspParams).call(transactionOptions);
-  console.log("Simulation successful. Expected Address:", address);
+  await lspCreator.methods.createLongShortPair(lspParams).call(transactionOptions);
 
   // Since the simulated transaction succeeded, send the real one to the network.
   if (!argv.simulate) {
     const { transactionHash } = await lspCreator.methods.createLongShortPair(lspParams).send(transactionOptions);
     console.log("Deployed in transaction:", transactionHash);
+  }
+
+  let address;
+  if (!argv.simulate) {
+    const { transactionHash } = await lspCreator.methods.createLongShortPair(lspParams).send(transactionOptions);
+    address = (await longShortPairCreator.getPastEvents("CreatedLongShortPair"))[0].returnValues.longShortPair;
+    console.log("Deployed in transaction:", transactionHash, "LSP Address:", address);
   }
 
   // Set the FPL parameters.

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "@ethersproject/bignumber": "^5.0.14",
     "@truffle/hdwallet-provider": "^1.2.1",
-    "@uma/core": "^2.30.0",
-    "@uma/contracts-node": "^0.3.9",
+    "@uma/core": "^2.31.0",
+    "@uma/contracts-node": "^0.3.10",
     "minimist": "^1.2.5",
     "web3": "^1.3.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,10 +2337,10 @@
     web3 "^1.6.0"
     winston "^3.2.1"
 
-"@uma/common@^2.22.0":
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/@uma/common/-/common-2.22.0.tgz#834f3f196965e43a831c165992014bfca661bbf7"
-  integrity sha512-xiT9Styoldnf6MDM/4GRXu0kFQEpERV4ieirmuo3YUmdrXKdctJ2G9dNRX3dmXNAG1Ixmb2GtZakWGXfdsGCvg==
+"@uma/common@^2.23.0":
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/@uma/common/-/common-2.23.0.tgz#e52a28a540ddc6ee51e846b565be838b9a078053"
+  integrity sha512-tIznpM0nLc4lHhRUrPUy3ziSIrE8nVjpmwEOYJHEHOXpDs5vEHJHLkR0XsjQBkF0qT4WBrNZmT5cCRjLJtcVHQ==
   dependencies:
     "@across-protocol/contracts" "^0.1.4"
     "@eth-optimism/hardhat-ovm" "^0.2.2"
@@ -2374,10 +2374,10 @@
     web3 "^1.6.0"
     winston "^3.2.1"
 
-"@uma/contracts-node@^0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.3.9.tgz#d3b64080f47cda4f1d8aacaaddebadbb880137a4"
-  integrity sha512-fvHofU/9Zg35snmuayQHumlvJz5f0omsxNgckLHWEFzKXb7RLKBSJRksxeH1NQEthia6jc1UQBnn6T2lucXJMw==
+"@uma/contracts-node@^0.3.10":
+  version "0.3.10"
+  resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.3.10.tgz#12f90873e83ba478b16c019d1c5d232e4d5ee782"
+  integrity sha512-jlWY1MIHu+kPEiV/JJaV+Mu5mCWWwEvXgnwNwdfSILKr6fn9sTk3HYPIMpt969794NbJg1RJAQshGXWPkFzhOA==
 
 "@uma/core@^2.18.0":
   version "2.28.0"
@@ -2395,16 +2395,16 @@
     "@uniswap/v3-core" "^1.0.0-rc.2"
     "@uniswap/v3-periphery" "^1.0.0-beta.23"
 
-"@uma/core@^2.30.0":
-  version "2.30.0"
-  resolved "https://registry.yarnpkg.com/@uma/core/-/core-2.30.0.tgz#0582229c638009bcda52093b18287bb2029e4f0d"
-  integrity sha512-4b9ALC3XDzCQW7SdHIQs1KQBfQ2FXPAkFfl8pKLgWT6vw5KyHAToAbTmuBSza6ldQZVgAoEoIZE2Bs32MpTzBQ==
+"@uma/core@^2.31.0":
+  version "2.31.0"
+  resolved "https://registry.yarnpkg.com/@uma/core/-/core-2.31.0.tgz#ccb9c250855d64d9febc4a48d6195b78b8ca0426"
+  integrity sha512-CQZOUXi/i436DsjAPWfOOKbO04Vn9a7ec73L7Ou2sOkob4+DiHkHT2mi9dPvqkjYkVXnW04rEXpqmrpEiEGpMQ==
   dependencies:
     "@gnosis.pm/safe-contracts" "^1.3.0"
     "@gnosis.pm/zodiac" "1.0.3"
     "@maticnetwork/fx-portal" "^1.0.4"
     "@openzeppelin/contracts" "4.4.2"
-    "@uma/common" "^2.22.0"
+    "@uma/common" "^2.23.0"
     "@uniswap/lib" "4.0.1-alpha"
     "@uniswap/v2-core" "1.0.0"
     "@uniswap/v2-periphery" "1.1.0-beta.0"


### PR DESCRIPTION
Changes proposed:

- Updated the UMA packages to include the most recent addresses for contracts
- Get the LSP token address from the events instead of [using the simulated transaction output](https://github.com/UMAprotocol/launch-lsp/blob/fabe4653f5c970a05bcaf0d30ec7cc5d0321c359/index.js#L180). 